### PR TITLE
Fix wrong usages of API in Example 1

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1324,9 +1324,12 @@ excel_path = "Enter Path to Excel Here" #example: C:\\Users\Bob\\Desktop\\RPA Ex
 lookup_terms = []
 for col in range(2,10):
     try:
-        lookup_terms.append(ExcelReadCell(excel_path, 2, col))
+        lookup_terms.append(ExcelRowCol(excel_path, 1, col))
     except:
         pass
+
+# Remove None from the list
+lookup_terms = list(filter(lambda x: x is not None, lookup_terms))
 
 # Open Chrome
 browser = ChromeBrowser()
@@ -1352,7 +1355,7 @@ for j,item in enumerate(lookup_terms):
 
     # Write found urls to Excel
     for i,url in enumerate(urls):
-        ExcelWriteCell(excel_path, row=i+2, col=j+2, write_value=url)
+        ExcelWriteRowCol(excel_path, r=i+2, c=j+2, write_value=url)
 
 # Exit the browser
 browser.quit()


### PR DESCRIPTION
I propose a few fix about the document.

* Change to use `ExcelReadRowCol` instead of `ExcelReadCell` to use the row and column number to specify the cell.
* According to the example image of Excel, the row number should be `1`
* If we don't provide enough number of words, the list `loolup_words` includes `None`. These `None` causes exceptions in the later part. This is why, I inserted a procedure to remove `None` from it.
* Change to use `ExcelWriteRowCol` instead of `ExcelWriteCell`. The same reason with the above.