### PR TITLE
Use "lower" method in comparing process names

### DIFF
--- a/automagica/activities.py
+++ b/automagica/activities.py
@@ -332,7 +332,7 @@ def ProcessRunning(name):
     '''
     if name:
         for p in psutil.process_iter():
-            if name in p.name():
+            if name in p.name().lower():
                 return True
     return False
 
@@ -352,7 +352,7 @@ def ChromeRunning():
     Returns True is Chrome is running.
     '''
     for p in psutil.process_iter():
-        if "chrome.exe" in p.name():
+        if "chrome.exe" in p.name().lower():
             return True
     return False
 
@@ -372,7 +372,7 @@ def ExcelRunning():
     Returns True is Excel is running.
     '''
     for p in psutil.process_iter():
-        if "excel.exe" in p.name():
+        if "excel.exe" in p.name().lower():
             return True
     return False
 
@@ -382,7 +382,7 @@ def PowerpointRunning():
     Returns True is Powerpoint is running.
     '''
     for p in psutil.process_iter():
-        if "powerpnt.exe" in p.name().lower:
+        if "powerpnt.exe" in p.name().lower():
             return True
     return False
 


### PR DESCRIPTION
I found some methods about checking if a process is running are using `lower` method to convert string to the lower case.
However, not all methods uses `lower` method.

I propose all Running* methods use `lower` method before comparing strings.