### PR TITLE
fixed word proccess left open in ConvertWordToPDF

### DIFF
--- a/automagica/activities.py
+++ b/automagica/activities.py
@@ -806,6 +806,7 @@ def ConvertWordToPDF(word_filename=None, pdf_filename=None):
         word_document = word.Documents.Open(word_filename)
         word_document.SaveAs(pdf_filename, FileFormat=17)
         word_document.Close()
+        word.Quit()
     else:
         print('Not implemented for other platforms than Windows.')
 


### PR DESCRIPTION
The `ConvertWordToPDF` function are lefting the word proccess opened.
I fixed that - it's really one line of code.

Otherwise, thanks for the project!